### PR TITLE
document nvidia support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you have multiple GPUs you need to pass both the setting for the render node 
 
 ```
 -e DRINODE=/dev/dri/renderD129 \
--e DRINODE=/dev/dri/renderD129
+-e DRI_NODE=/dev/dri/renderD129
 ```
 
 Nvidia support only works on 580 and up full proprietary drivers (no MIT/GPL) with `nvidia-drm.modeset=1` kernel parameter set. You must ensure the card is initialized before running a container so on headless systems run `nvidia-modprobe --modeset` from the host even with this kernel parameter set, this only needs to be run once per boot.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,7 @@ app_setup_block: |
 
   ```
   -e DRINODE=/dev/dri/renderD129 \
-  -e DRINODE=/dev/dri/renderD129
+  -e DRI_NODE=/dev/dri/renderD129
   ```
 
   Nvidia support only works on 580 and up full proprietary drivers (no MIT/GPL) with `nvidia-drm.modeset=1` kernel parameter set. You must ensure the card is initialized before running a container so on headless systems run `nvidia-modprobe --modeset` from the host even with this kernel parameter set, this only needs to be run once per boot.


### PR DESCRIPTION
I could not figure this out for a long time, it turns out because my Nvidia card is cold I needed to run `nvidia-modprobe --modeset` to get vulkan working at the host level  (required node for vulkan) This will be the same story on headless servers. This needs to be run on every boot. 

I tested a bunch of modern titles they all run great. 

https://github.com/user-attachments/assets/6a00d0b9-2a41-4e67-a8e0-b40eb64c306a

