### PR TITLE
#4 add umu-launcher and protonup qt for decoupled Steam game launching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,24 @@ RUN \
     "https://cdn.fastly.steamstatic.com/client/installer/steam.deb" && \
   apt-get install -y \
     /tmp/steam.deb && \
+  echo "**** install umu run ****" && \
+  UMU_RELEASE=$(curl -sX GET "https://api.github.com/repos/Open-Wine-Components/umu-launcher/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+  curl -o \
+    /tmp/umu.deb -L \
+    "https://github.com/Open-Wine-Components/umu-launcher/releases/download/${UMU_RELEASE}/python3-umu-launcher_${UMU_RELEASE}-1_amd64_debian-13.deb" && \
+  apt-get install -y \
+    /tmp/umu.deb && \
+  echo "**** install protonupqt ****" && \
+  PRQT_RELEASE=$(curl -sX GET "https://api.github.com/repos/DavidoTek/ProtonUp-Qt/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+  curl -o \
+    /tmp/prqt.app -L \
+    "https://github.com/DavidoTek/ProtonUp-Qt/releases/download/${PRQT_RELEASE}/ProtonUp-Qt-$(echo ${PRQT_RELEASE} | sed 's/^v//g')-x86_64.AppImage" && \
+  cd /tmp &&  \
+  chmod +x prqt.app && \
+  ./prqt.app --appimage-extract && \
+  mv squashfs-root /opt/protonup-qt && \
   echo "**** install 32 bit interposers ****" && \
   cd /tmp && \
   git clone \

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ This container leverages a userspace gamepad interposer to provide gamepad suppo
 
 An absolute must for mouse and keyboard input is sending relative mouse input from the browser, you will need to use the "Gaming Mode" which is a small crosshair in the top right of the sidebar. This runs in fullscreen and traps you in the window, to exit this mode hold down escape for 3 seconds.
 
+## Game Launching
+
+Included in this image are tools for managing [Proton versions](https://davidotek.github.io/protonup-qt/) and a [command line launcher](https://github.com/Open-Wine-Components/umu-launcher). This means once a game or application is installed via Steam it can be directly launched on init by creating a config file and modifying `/config/.config/labwc/autostart` to run `umu-run` instead of Steam.: 
+
+```
+umu-run --config /config/game.toml
+```
+
+```toml
+[umu]
+prefix = "/config/game"
+exe = "/config/Desktop/game/game.exe"
+proton = "/config/.local/share/Steam/compatibilitytools.d/GE-Proton-version"
+game_id = "0"
+```
+
+This facilitates custom home directories with pre-configured runtimes and gamefiles for baking images outside of using the Steam launcher.
+
 ### Strict reverse proxies
 
 This image uses a self-signed certificate by default. This naturally means the scheme is `https`.
@@ -623,5 +641,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **04.02.26:** - Add ProtonUp Qt for runtime management and umu-run for custom auto game launching.
 * **17.01.26:** - Document Nvidia support.
 * **09.01.26:** - Initial Version.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -65,6 +65,25 @@ app_setup_block: |
   ## Gaming mode
 
   An absolute must for mouse and keyboard input is sending relative mouse input from the browser, you will need to use the "Gaming Mode" which is a small crosshair in the top right of the sidebar. This runs in fullscreen and traps you in the window, to exit this mode hold down escape for 3 seconds.
+
+  ## Game Launching
+
+  Included in this image are tools for managing [Proton versions](https://davidotek.github.io/protonup-qt/) and a [command line launcher](https://github.com/Open-Wine-Components/umu-launcher). This means once a game or application is installed via Steam it can be directly launched on init by creating a config file and modifying `/config/.config/labwc/autostart` to run `umu-run` instead of Steam.: 
+
+  ```
+  umu-run --config /config/game.toml
+  ```
+
+  ```toml
+  [umu]
+  prefix = "/config/game"
+  exe = "/config/Desktop/game/game.exe"
+  proton = "/config/.local/share/Steam/compatibilitytools.d/GE-Proton-version"
+  game_id = "0"
+  ```
+
+  This facilitates custom home directories with pre-configured runtimes and gamefiles for baking images outside of using the Steam launcher. 
+
 # init diagram
 init_diagram: |
   "steam:latest": {
@@ -137,5 +156,6 @@ init_diagram: |
   "steam:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "04.02.26:", desc: "Add ProtonUp Qt for runtime management and umu-run for custom auto game launching."}
   - {date: "17.01.26:", desc: "Document Nvidia support."}
   - {date: "09.01.26:", desc: "Initial Version."}

--- a/root/defaults/menu_wayland.xml
+++ b/root/defaults/menu_wayland.xml
@@ -3,5 +3,6 @@
 <menu id="root-menu" label="MENU">
 <item label="foot" icon="/usr/share/icons/hicolor/48x48/apps/foot.png"><action name="Execute"><command>/usr/bin/foot</command></action></item>
 <item label="Steam" icon="/usr/share/icons/hicolor/48x48/apps/steam.png"><action name="Execute"><command>/usr/bin/wrapped-steam</command></action></item>
+<item label="ProtonUp-Qt" icon="/opt/protonup-qt/net.davidotek.pupgui2.png"><action name="Execute"><command>/opt/protonup-qt/AppRun</command></action></item>
 </menu>
 </openbox_menu>


### PR DESCRIPTION
This facilitates users to easily install Proton GE which I have found is a must for unlisted abandonware. It also adds umu-launcher and some docs. 

People can modify their autostart init and directly launch custom or offline vintage games with this instead of logging in and hopping through Steam. 